### PR TITLE
utils/url - add typing for ret in encodeQueryData

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": true,
+  "singleQuote": false,
+  "endOfLine": "lf"
+}

--- a/lib/utils/url.utils.ts
+++ b/lib/utils/url.utils.ts
@@ -1,11 +1,13 @@
 // https://stackoverflow.com/a/111545/5463235
 export function encodeQueryData(data: any) {
     try {
-        const ret = [];
+        const ret: string[] = [];
         for (const key of Object.keys(data))
-            ret.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
-        return ret.join('&');
+            ret.push(
+                `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`
+            );
+        return ret.join("&");
     } catch (_) {
-        return ''
+        return "";
     }
 }


### PR DESCRIPTION
Specify variable `ret`'s type to `string[]` type from `never[]`

<img width="583" alt="스크린샷 2020-12-18 오후 11 14 28" src="https://user-images.githubusercontent.com/32605822/102624025-c7e48f00-4186-11eb-9106-b4a0666e837c.png">
